### PR TITLE
Fix lint, install deps as non-root in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
-FROM python:3.10.0-alpine
-MAINTAINER Thermondo GmbH
+FROM python:3.10-alpine
 
-ENV PYTHONUNBUFFERED 1
+ENV PYTHONUNBUFFERED=1
+ENV PATH="/home/user/.local/bin:${PATH}"
+
+WORKDIR /app
+
+RUN adduser -D user && chown -R user:user /app
+USER user
 
 COPY ./requirements.txt /requirements.txt
-RUN pip install -r /requirements.txt
+RUN pip install --no-cache-dir -r /requirements.txt
 
-RUN mkdir /app
-WORKDIR /app
 COPY ./app /app
-
-RUN adduser -D user
-USER user


### PR DESCRIPTION
Changed Dockerfile to be less ideal for a production app, but more ideal for running untrusted third-party code. Also fixed some lint and build warnings.

## Description

I find that I always modify the Dockerfile a little bit before actually testing the code on my machine. Fewer commands running as root, etc., which is more important for Linux devs.

## How to test / reproduce

```bash
make build
```

## Review checklist

- [x] PR is ready
    - PR is split into meaningful commits (if needed) for the ease of reviewing
    - Description contains clear instructions on how to test the feature
- [ ] Tests have been written
- [ ] Appropriate labels have been applied
